### PR TITLE
Initial guide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM openjdk:8-jre-alpine
-COPY hazelcast-embedded-springboot/target/hazelcast-embedded-springboot-0.1.jar app.jar
+COPY hazelcast-embedded-springboot/target/*.jar app.jar
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:8-jre-alpine
+COPY hazelcast-embedded-springboot/target/hazelcast-embedded-springboot-0.1.jar app.jar
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/README.adoc
+++ b/README.adoc
@@ -46,18 +46,9 @@ hazelcast:
 
 To include this file inside your Spring Boot project, put it into `hazelcast-embedded-springboot/src/resources/`.
 
-Alternatively, you can inline your Hazelcast configuration inside the Java code.
-
-[source, java]
-----
-public Config hazelcastConfig() {
-    Config config = new Config();
-    JoinConfig joinConfig = config.getNetworkConfig().getJoin();
-    joinConfig.getMulticastConfig().setEnabled(false);
-    joinConfig.getKubernetesConfig().setEnabled(true);
-    return config;
-}
-----
+---
+cp hazelcast.yaml hazelcast-embedded-springboot/src/main/resources/
+---
 
 Now, you can build the project with the following command.
 
@@ -65,13 +56,105 @@ Now, you can build the project with the following command.
 mvn package -f hazelcast-embedded-springboot/pom.xml
 ---
 
-As an output, the JAR file with our application should be created at `hazelcast-embedded-springboot/target/`.
+As an output, the JAR file with our application should be created at `hazelcast-embedded-springboot/target/hazelcast-embedded-springboot-0.1.jar`.
 
 == Containerize the Application
 
+To containerize the application, you need to have Docker installed. Then, you can use the following `Dockerfile`.
+
+[source, dockerfile]
+----
+FROM openjdk:8-jre-alpine
+COPY hazelcast-embedded-springboot/target/hazelcast-embedded-springboot-0.1.jar app.jar
+ENTRYPOINT ["java","-jar","app.jar"]
+----
+
+In order to build the Docker image, run the following command.
+
+---
+docker build -t hazelcastguides/hazelcast-embedded-kubernetes .
+---
+
+If you build the image by yourself, then you need to use your Docker Hub account instead of `hazelcastguides`. Then, you can push the image into your Docker Hub registry with the following command.
+
+---
+docker push hazelcastguides/hazelcast-embedded-kubernetes
+---
+
+If you want to use your image in the following steps, please also make sure your Docker Hub registry is public. However, For the purpose of this guide, you can also use the already built `hazelcastguides/hazelcast-embedded-kubernetes` Docker image.
 
 
 == Configure RBAC
 
+https://github.com/hazelcast/hazelcast-kubernetes[Hazelcast Kubernetes discovery plugin] makes calls to Kubernetes API to provide automatic and dynamic member discovery. Therefore, it needs to have the specific ClusterRole rules granted. You can apply the minimal RBAC configuration (for the `default` service account in the `default` namespace) with the following command.
+
+---
+kubectl apply -f https://raw.githubusercontent.com/hazelcast/hazelcast-kubernetes/master/rbac.yaml
+---
+
+Note that:
+- If you use other service account or other namespace, you need to modify https://raw.githubusercontent.com/hazelcast/hazelcast-kubernetes/master/rbac.yaml
+- If your Kubernetes cluster does not use RBAC, you can skip this step
+
 == Deploy the Application to Kubernetes
+
+Assuming you have a running Kubernetes cluster, you can run the following commands to deploy your application and scale it to 2 replicas.
+
+---
+kubectl create deployment my-app --image=hazelcastguides/hazelcast-embedded-kubernetes
+kubectl scale deployment my-app --replicas=2
+---
+
+Now, if you look into the created pods, you should see two replicas of your application.
+
+---
+$ kubectl get pods
+NAME                      READY   STATUS    RESTARTS   AGE
+my-app-86df8b785f-4x9pj   1/1     Running   0          81s
+my-app-86df8b785f-h926d   1/1     Running   0          73s
+---
+
+In your application logs, you should see that embedded Hazelcast instances formed one cluster together.
+
+---
+$ kubectl logs pod/my-app-86df8b785f-4x9pj
+...
+Members {size:2, ver:2} [
+        Member [10.24.1.10]:5701 - a7eb36b6-6d86-4d26-8eb6-47986e46d055 this
+        Member [10.24.2.6]:5701 - 9994d6c6-d271-4ddd-9aa9-1ac4767c1a73
+]
+---
+
+== Testing the Application
+
+To test that application works correctly, you can create a Kubernetes service which will load balance the traffic to one of the application replicas.
+
+---
+kubectl create service clusterip my-app --tcp=8080:8080
+---
+
+Then, to be able to make calls from your local machine, you can use `port-forward`.
+
+---
+kubectl port-forward service/my-app 8080:8080
+---
+
+Finally, you can make a REST calls to your application.
+
+---
+$ curl --data "key=key1&value=hazelcast" "localhost:8080/put"
+{"value":"hazelcast"}
+$ curl "localhost:8080/get?key=key1"
+{"value":"hazelcast"}
+
+---
+
+== Tearing Down the Deployment
+
+To delete all Kubernetes resources you created, run the following command.
+
+---
+kubectl delete deployment/my-app service/my-app
+---
+
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,13 +5,13 @@
 
 = Getting Started with Embedded Hazelcast on Kubernetes
 
-This guide will get you started to Embedded Hazelcast on the Kubernetes environment.
+This guide will get you started to use Embedded Hazelcast on the Kubernetes environment.
 
 include::{templates-url}/link-to-repo.adoc[]
 
 == What You’ll Learn
 
-In this guide, you'll deploy an application with embedded Hazelcast into a Kubernetes cluster. Hazelcast instances from each application replica will all automatically discover themselves and form one consistent Hazelcast cluster. Thanks to https://github.com/hazelcast/hazelcast-kubernetes[Hazelcast Kubernetes discovery plugin], there is not static configuration needed.
+In this guide, you'll deploy an application with embedded Hazelcast into a Kubernetes cluster. Hazelcast instances from each application replica will all automatically discover themselves and form one consistent Hazelcast cluster. Thanks to https://github.com/hazelcast/hazelcast-kubernetes[Hazelcast Kubernetes discovery plugin], there is no static configuration needed.
 
 == Prerequisites
 
@@ -19,19 +19,20 @@ In this guide, you'll deploy an application with embedded Hazelcast into a Kuber
 - https://docs.docker.com/install/[Docker] (https://www.docker.com/products/docker-desktop[Docker for Desktop] is good enough)
 - https://kubernetes.io/[Kubernetes] cluster (https://www.docker.com/products/docker-desktop[Docker for Desktop] or https://minikube.sigs.k8s.io/docs/[Minikube] is good enough)
 - https://git-scm.com/[Git]
-include::{templates-url}/microservices/prerequisites.adoc[]
+- JDK 1.8+
+- Apache Maven 3.2+
 
 == Create an Application
 
 You can embed Hazelcast into any JVM-based application and use any web framework you want. As the sample for this guide, let's use the application from https://github.com/hazelcast-guides/hazelcast-embedded-springboot[Getting Started with Hazelcast using Spring Boot] guide. To download it, execute the following command.
 
----
+----
 git clone https://github.com/hazelcast-guides/hazelcast-embedded-springboot.git
----
+----
 
 == Use Hazelcast Kubernetes Configuration
 
-Hazelcast provides the dedicated https://github.com/hazelcast/hazelcast-kubernetes[Hazelcast Kubernetes plugin] which allows to automatically form Hazelcast cluster in the Kubernetes environment. To enabled it, use the following `hazelcast.yaml` as your Hazelcast configuration.
+Hazelcast provides the dedicated https://github.com/hazelcast/hazelcast-kubernetes[Hazelcast Kubernetes plugin] which allows to automatically form Hazelcast cluster in the Kubernetes environment. To enabled it, use the following Hazelcast configuration.
 
 [source, yaml]
 ----
@@ -44,19 +45,19 @@ hazelcast:
         enabled: true
 ----
 
-To include this file inside your Spring Boot project, put it into `hazelcast-embedded-springboot/src/resources/`.
+To include this file inside your Spring Boot project, copy it into `hazelcast-embedded-springboot/src/resources/`.
 
----
+----
 cp hazelcast.yaml hazelcast-embedded-springboot/src/main/resources/
----
+----
 
 Now, you can build the project with the following command.
 
----
+----
 mvn package -f hazelcast-embedded-springboot/pom.xml
----
+----
 
-As an output, the JAR file with our application should be created at `hazelcast-embedded-springboot/target/hazelcast-embedded-springboot-0.1.jar`.
+As an output, the JAR file with our application should be created at `hazelcast-embedded-springboot/target/*.jar`.
 
 == Containerize the Application
 
@@ -65,96 +66,97 @@ To containerize the application, you need to have Docker installed. Then, you ca
 [source, dockerfile]
 ----
 FROM openjdk:8-jre-alpine
-COPY hazelcast-embedded-springboot/target/hazelcast-embedded-springboot-0.1.jar app.jar
+COPY hazelcast-embedded-springboot/target/*.jar app.jar
 ENTRYPOINT ["java","-jar","app.jar"]
 ----
 
 In order to build the Docker image, run the following command.
 
----
+----
 docker build -t hazelcastguides/hazelcast-embedded-kubernetes .
----
+----
 
 If you build the image by yourself, then you need to use your Docker Hub account instead of `hazelcastguides`. Then, you can push the image into your Docker Hub registry with the following command.
 
----
+----
 docker push hazelcastguides/hazelcast-embedded-kubernetes
----
+----
 
-If you want to use your image in the following steps, please also make sure your Docker Hub registry is public. However, For the purpose of this guide, you can also use the already built `hazelcastguides/hazelcast-embedded-kubernetes` Docker image.
+If you want to use your image in the following steps, please also make sure your Docker Hub registry is public. However, for the purpose of this guide, you can also use the already built `hazelcastguides/hazelcast-embedded-kubernetes` Docker image.
 
 
 == Configure RBAC
 
-https://github.com/hazelcast/hazelcast-kubernetes[Hazelcast Kubernetes discovery plugin] makes calls to Kubernetes API to provide automatic and dynamic member discovery. Therefore, it needs to have the specific ClusterRole rules granted. You can apply the minimal RBAC configuration (for the `default` service account in the `default` namespace) with the following command.
+https://github.com/hazelcast/hazelcast-kubernetes[Hazelcast Kubernetes discovery plugin] makes calls to Kubernetes API to provide automatic member discovery. Therefore, it needs to have specific ClusterRole rules granted. You can apply the minimal RBAC configuration (for the `default` service account in the `default` namespace) with the following command.
 
----
+----
 kubectl apply -f https://raw.githubusercontent.com/hazelcast/hazelcast-kubernetes/master/rbac.yaml
----
+----
 
 Note that:
-- If you use other service account or other namespace, you need to modify https://raw.githubusercontent.com/hazelcast/hazelcast-kubernetes/master/rbac.yaml
-- If your Kubernetes cluster does not use RBAC, you can skip this step
+
+- If you use service account other than `default` or namespace other than `default`, you need to modify https://raw.githubusercontent.com/hazelcast/hazelcast-kubernetes/master/rbac.yaml
+- If your Kubernetes cluster does not use RBAC, you can skip the "Configure RBAC" step
 
 == Deploy the Application to Kubernetes
 
 Assuming you have a running Kubernetes cluster, you can run the following commands to deploy your application and scale it to 2 replicas.
 
----
+----
 kubectl create deployment my-app --image=hazelcastguides/hazelcast-embedded-kubernetes
 kubectl scale deployment my-app --replicas=2
----
+----
 
-Now, if you look into the created pods, you should see two replicas of your application.
+Now, if you look into created pods, you should see two replicas of your application.
 
----
+----
 $ kubectl get pods
 NAME                      READY   STATUS    RESTARTS   AGE
 my-app-86df8b785f-4x9pj   1/1     Running   0          81s
 my-app-86df8b785f-h926d   1/1     Running   0          73s
----
+----
 
 In your application logs, you should see that embedded Hazelcast instances formed one cluster together.
 
----
+----
 $ kubectl logs pod/my-app-86df8b785f-4x9pj
 ...
 Members {size:2, ver:2} [
         Member [10.24.1.10]:5701 - a7eb36b6-6d86-4d26-8eb6-47986e46d055 this
         Member [10.24.2.6]:5701 - 9994d6c6-d271-4ddd-9aa9-1ac4767c1a73
 ]
----
+----
 
 == Testing the Application
 
-To test that application works correctly, you can create a Kubernetes service which will load balance the traffic to one of the application replicas.
+To test that the application works correctly, you can create a Kubernetes service which load balances the traffic to one of the application replicas.
 
----
+----
 kubectl create service clusterip my-app --tcp=8080:8080
----
+----
 
 Then, to be able to make calls from your local machine, you can use `port-forward`.
 
----
+----
 kubectl port-forward service/my-app 8080:8080
----
+----
 
 Finally, you can make a REST calls to your application.
 
----
+----
 $ curl --data "key=key1&value=hazelcast" "localhost:8080/put"
 {"value":"hazelcast"}
 $ curl "localhost:8080/get?key=key1"
 {"value":"hazelcast"}
 
----
+----
 
 == Tearing Down the Deployment
 
 To delete all Kubernetes resources you created, run the following command.
 
----
+----
 kubectl delete deployment/my-app service/my-app
----
+----
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,77 @@
+:github-address: https://github.com/hazelcast-guides/hazelcast-embedded-kubernetes
+:templates-url: https://raw.githubusercontent.com/hazelcast-guides/adoc-templates/master
+:hazelcast: Hazelcast IMDG
+:framework: Kubernetes
+
+= Getting Started with Embedded Hazelcast on Kubernetes
+
+This guide will get you started to Embedded Hazelcast on the Kubernetes environment.
+
+include::{templates-url}/link-to-repo.adoc[]
+
+== What You’ll Learn
+
+In this guide, you'll deploy an application with embedded Hazelcast into a Kubernetes cluster. Hazelcast instances from each application replica will all automatically discover themselves and form one consistent Hazelcast cluster. Thanks to https://github.com/hazelcast/hazelcast-kubernetes[Hazelcast Kubernetes discovery plugin], there is not static configuration needed.
+
+== Prerequisites
+
+- ~15 minutes
+- https://docs.docker.com/install/[Docker] (https://www.docker.com/products/docker-desktop[Docker for Desktop] is good enough)
+- https://kubernetes.io/[Kubernetes] cluster (https://www.docker.com/products/docker-desktop[Docker for Desktop] or https://minikube.sigs.k8s.io/docs/[Minikube] is good enough)
+- https://git-scm.com/[Git]
+include::{templates-url}/microservices/prerequisites.adoc[]
+
+== Create an Application
+
+You can embed Hazelcast into any JVM-based application and use any web framework you want. As the sample for this guide, let's use the application from https://github.com/hazelcast-guides/hazelcast-embedded-springboot[Getting Started with Hazelcast using Spring Boot] guide. To download it, execute the following command.
+
+---
+git clone https://github.com/hazelcast-guides/hazelcast-embedded-springboot.git
+---
+
+== Use Hazelcast Kubernetes Configuration
+
+Hazelcast provides the dedicated https://github.com/hazelcast/hazelcast-kubernetes[Hazelcast Kubernetes plugin] which allows to automatically form Hazelcast cluster in the Kubernetes environment. To enabled it, use the following `hazelcast.yaml` as your Hazelcast configuration.
+
+[source, yaml]
+----
+hazelcast:
+  network:
+    join:
+      multicast:
+        enabled: false
+      kubernetes:
+        enabled: true
+----
+
+To include this file inside your Spring Boot project, put it into `hazelcast-embedded-springboot/src/resources/`.
+
+Alternatively, you can inline your Hazelcast configuration inside the Java code.
+
+[source, java]
+----
+public Config hazelcastConfig() {
+    Config config = new Config();
+    JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+    joinConfig.getMulticastConfig().setEnabled(false);
+    joinConfig.getKubernetesConfig().setEnabled(true);
+    return config;
+}
+----
+
+Now, you can build the project with the following command.
+
+---
+mvn package -f hazelcast-embedded-springboot/pom.xml
+---
+
+As an output, the JAR file with our application should be created at `hazelcast-embedded-springboot/target/`.
+
+== Containerize the Application
+
+
+
+== Configure RBAC
+
+== Deploy the Application to Kubernetes
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# hazelcast-embedded-kubernetes

--- a/create.sh
+++ b/create.sh
@@ -1,0 +1,2 @@
+asciidoctor -a allow-uri-read *.adoc;
+asciidoctor-pdf -a allow-uri-read *.adoc;

--- a/hazelcast.yaml
+++ b/hazelcast.yaml
@@ -1,0 +1,7 @@
+hazelcast:
+  network:
+    join:
+      multicast:
+        enabled: false
+      kubernetes:
+        enabled: true


### PR DESCRIPTION
Hazelcast Embedded Kubernetes guide. It's a separate guide, but it's kind-of a follow-up of the guide created by Alparslan: https://github.com/hazelcast-guides/hazelcast-embedded-springboot

-----------------------------------

I see this PR as an alternative to this PR: https://github.com/hazelcast-guides/hazelcast-embedded-springboot/pull/2. So I think we should decide which one to merge and close the other one.

In general, here's the difference:
- Approach from https://github.com/hazelcast-guides/hazelcast-embedded-springboot/pull/2:
  - Each guide is a complete story: from web framework (Spring Boot, Quarkus) to the Deployment steps (AWS, Kubernetes)
   - We probably will need to maintain multiple Kubernetes Deployment versions (for each web framework)

- This PR approach:
   - Each guide is one aspect of Hazelcast, so this one is dedicated to Hazelcast Embedded on Kubernetes (I don't think we need to create another one, like Hazelcast with Quarkus on Kubernetes, because this single one should be enough)

I generally like this second approach more. Not even because of mantuance problem But because I think in general people look for the knowledge when they have a problem with something. And then more granular guides are better.

Saying that, if we decide to go with the first approach, then I'm totally fine to just close this PR and remove `hazelcast-embedded-kubernetes` repo.

----------------------

One more thing. For this guide, I creates the DockerHub organization `hazelcastguides`. It's kind-of what Spring Boot did for their guides. If we go with this, I'll add you all to this org (but if we have more than 3 members, we have to pay 9$/month or something).